### PR TITLE
Fix build_number parameter description

### DIFF
--- a/lib/fastlane/plugin/ionic/actions/ionic_action.rb
+++ b/lib/fastlane/plugin/ionic/actions/ionic_action.rb
@@ -236,7 +236,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :build_number,
             env_name: "CORDOVA_BUILD_NUMBER",
-            description: "Build Number for iOS",
+            description: "Sets the build number for iOS and version code for Android",
             optional: true,
             is_string: false
           ),


### PR DESCRIPTION
The parameter affects the version code on Android as well. However, the description mentions that the parameter only works for iOS.