### PR TITLE
feat: Use locally installed Ionic (from `node_modules/.bin`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Which will produce:
 | **cordova_no_fetch**      | Specifies whether to run `ionic cordova platform add` with `--nofetch` parameter  | CORDOVA_NO_FETCH               |  *false*   |
 | **build_flag**           | An array of Xcode buildFlag. Will be appended on compile command.  | CORDOVA_IOS_BUILD_FLAG               | [] |
 | **cordova_build_config_file**      | Call `ionic cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path  | CORDOVA_BUILD_CONFIG_FILE               |     |
+| **use_local_ionic**      | Use locally installed Ionic instead of globally installed one. Useful for shared CI environments. | USE_LOCAL_IONIC                   | *false*    |
 
 
 ## Run tests for this plugin

--- a/lib/fastlane/plugin/ionic/actions/ionic_action.rb
+++ b/lib/fastlane/plugin/ionic/actions/ionic_action.rb
@@ -77,7 +77,7 @@ module Fastlane
       end
 
       def self.get_ionic_path(params)
-        return params[:use_local_ionic] ? "node_modules/.bin/" : ""
+        return params[:use_local_ionic] ? File.join("node_modules", ".bin", "") : ""
       end
 
       # add platform if missing (run step #1)

--- a/lib/fastlane/plugin/ionic/actions/ionic_action.rb
+++ b/lib/fastlane/plugin/ionic/actions/ionic_action.rb
@@ -76,15 +76,18 @@ module Fastlane
         return self.get_platform_args(params, IOS_ARGS_MAP)
       end
 
+      def self.get_ionic_path(params)
+        return params[:use_local_ionic] ? "node_modules/.bin/" : ""
+      end
+
       # add platform if missing (run step #1)
       def self.check_platform(params)
         platform = params[:platform]
         if platform && !File.directory?("./platforms/#{platform}")
-          ionic_path = params[:use_local_ionic] ? "node_modules/.bin/" : ""
           if params[:cordova_no_fetch]
-            sh "#{ionic_path}ionic cordova platform add #{platform} --no-interactive --nofetch"
+            sh "#{self.get_ionic_path(params)}ionic cordova platform add #{platform} --no-interactive --nofetch"
           else
-            sh "#{ionic_path}ionic cordova platform add #{platform} --no-interactive"
+            sh "#{self.get_ionic_path(params)}ionic cordova platform add #{platform} --no-interactive"
           end
         end
       end
@@ -102,8 +105,6 @@ module Fastlane
         args << '--prod' if params[:prod]
         args << '--browserify' if params[:browserify]
 
-        ionic_path = params[:use_local_ionic] ? "node_modules/.bin/" : ""
-
         if !params[:cordova_build_config_file].to_s.empty?
           args << "--buildConfig=#{Shellwords.escape(params[:cordova_build_config_file])}"
         end
@@ -113,7 +114,7 @@ module Fastlane
 
         if params[:cordova_prepare]
           # TODO: Remove params not allowed/used for `prepare`
-          sh "#{ionic_path}ionic cordova prepare #{params[:platform]} --no-interactive #{args.join(' ')}"
+          sh "#{self.get_ionic_path(params)}ionic cordova prepare #{params[:platform]} --no-interactive #{args.join(' ')}"
         end
 
         # special handling for `build_number` param


### PR DESCRIPTION
In my company we have  a couple of Mac Minis that are used for building iOS apps in CI.

It's common for projects to have different Ionic and/or Cordova versions, so using the globally installed Ionic is no good in this case.